### PR TITLE
Revert "Bump org.bouncycastle:bcprov-jdk18on from 1.77 to 1.78 in /tools/mat/configuration/org.eclipse.osgi/166/0/.cp/META-INF/maven/org.eclipse.mat/org.eclipse.mat.ui.rcp"

### DIFF
--- a/tools/mat/configuration/org.eclipse.osgi/166/0/.cp/META-INF/maven/org.eclipse.mat/org.eclipse.mat.ui.rcp/pom.xml
+++ b/tools/mat/configuration/org.eclipse.osgi/166/0/.cp/META-INF/maven/org.eclipse.mat/org.eclipse.mat.ui.rcp/pom.xml
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk18on</artifactId>
-      <version>1.78</version>
+      <version>1.77</version>
       <scope>compile</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Reverts miniLQ/onemore#1